### PR TITLE
[FIX] create user if they don't exist when staking

### DIFF
--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -90,6 +90,11 @@ export function increaseUserStakeBy(
   let dbUser = User.load(dbWallet.user);
   let dbContract = StakingContract.load(stakingContractAddress.toHex());
   let dbToken: Token = ensureToken(Address.fromString(dbContract.stakeToken));
+
+  if (!dbUser) {
+    dbUser = createUser(walletAddress, false, true, timestamp);
+  }
+  
   dbUser.totalStakedBalance = dbUser.totalStakedBalance.plus(
     toBigDecimal(value, dbToken.decimals)
   );

--- a/src/mappings/CommonsWhitelist.ts
+++ b/src/mappings/CommonsWhitelist.ts
@@ -3,7 +3,8 @@ import {
   OwnershipTransferred,
   AddedToWhitelist,
   RemovedFromWhitelist,
-  UpdatedWhitelistAddress
+  UpdatedWhitelistAddress,
+  MassAdd
 } from "./../../generated/CommonsWhitelist/CommonsWhitelist";
 import {
   createWhitelistContract,
@@ -19,6 +20,13 @@ import {
 import { createAddedToWhitelistEvent } from "../entities/AddedToWhitelistEvent";
 import { createRemovedFromWhitelistEvent } from "../entities/RemovedFromWhitelistEvent";
 import { createUpdatedWhitelistAddressEvent } from "../entities/UpdatedWhitelistAddressEvent";
+
+import { log } from "@graphprotocol/graph-ts";
+
+export function handleMassAdd(event: MassAdd): void {
+  let accounts = event.params.accounts;
+  log.info('mass add {}', [accounts.toHexString()])
+}
 
 export function handleOwnershipTransferred(event: OwnershipTransferred): void {
   let dbContract = WhitelistContract.load(event.address.toHex());

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -28,6 +28,8 @@ dataSources:
           handler: handleRemovedFromWhitelist
         - event: UpdatedWhitelistAddress(indexed address,indexed address)
           handler: handleUpdatedWhitelistAddress
+        - event: MassAdd(indexed address[],bool[])
+          handler: handleMassAdd
       file: ./src/mappings/CommonsWhitelist.ts
 
 


### PR DESCRIPTION
Handles a case where a user stakes but we don't have a `User` entity for them, causing an indexing error.