### PR TITLE
fix: merkle contract addresses and start blocks

### DIFF
--- a/configs/matic.json
+++ b/configs/matic.json
@@ -4,6 +4,6 @@
   "whitelist_startBlock": 15871898,
   "staking_contract": "0x8bF5aD0dBa1e29741740D96E55Bf27Aec30B18E2",
   "staking_startBlock": 15871970,
-  "merkleRedeem_contract": "0xBDc0b7C32401034E2E4c6d03FC9D5c0a5999B0d8",
-  "merkleRedeem_startBlock": 17307388
+  "merkleRedeem_contract": "0xd8C5C9D730f66cc42dB4b5A5E43b2e872d34424B",
+  "merkleRedeem_startBlock": 18710838
 }

--- a/configs/mumbai.json
+++ b/configs/mumbai.json
@@ -4,6 +4,6 @@
   "whitelist_startBlock": 17224384,
   "staking_contract": "0x4E0b295e8E24f841740eCc94CfbE3E75aDcD6955",
   "staking_startBlock": 17302112,
-  "merkleRedeem_contract": "0xBDc0b7C32401034E2E4c6d03FC9D5c0a5999B0d8",
-  "merkleRedeem_startBlock": 17307388
+  "merkleRedeem_contract": "0xB3F54a4C816Be3Baae88Eb49711Dc6Eb63632F6c",
+  "merkleRedeem_startBlock": 17523235
 }


### PR DESCRIPTION
Changes the config to have the correct address/start block for the merkle redeem contracts. Start blocks are set to the contract deployment block.

Addresses are listed here: https://github.com/opolis/work-distribution_contracts#deployments