### PR TITLE
Add bigint id field to payrolls and stakes

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -44,6 +44,7 @@ type Token @entity {
 
 type Payroll @entity {
   id: ID! # payrollId
+  payrollId: BigInt!
   payor: Bytes! # address of the payor
   token: Token!
   amount: BigDecimal!
@@ -53,6 +54,7 @@ type Payroll @entity {
 
 type Stake @entity {
   id: ID! # memberId (stakeId)
+  memberId: BigInt!
   staker: Bytes! # address of the payor
   token: Token!
   amount: BigDecimal!

--- a/src/entities/OpolisPayStake.ts
+++ b/src/entities/OpolisPayStake.ts
@@ -12,6 +12,7 @@ export function createStake(
 ): void {
   let dbStake = new Stake(id.toString());
   let dbToken = ensureToken(token);
+  dbStake.memberId = id;
   dbStake.amount = toBigDecimal(amount, dbToken.decimals);
   dbStake.staker = staker;
   dbStake.token = dbToken.id;

--- a/src/entities/Payroll.ts
+++ b/src/entities/Payroll.ts
@@ -12,6 +12,7 @@ export function createPayroll(
 ): void {
   let dbPayroll = new Payroll(id.toString());
   let dbToken = ensureToken(token);
+  dbPayroll.payrollId = id;
   dbPayroll.amount = toBigDecimal(amount, dbToken.decimals);
   dbPayroll.payor = payor;
   dbPayroll.token = dbToken.id;


### PR DESCRIPTION
Currently payrolls and stakes can't be sorted quite right via `orderBy` on their ids since they're strings. This pr adds a BigInt field with the id data.